### PR TITLE
ssh kitten: add optional password/TOTP auto-fill via ssh.conf

### DIFF
--- a/kittens/ssh/askpass.go
+++ b/kittens/ssh/askpass.go
@@ -3,11 +3,15 @@
 package ssh
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"strings"
-	"time"
+    "crypto/hmac"
+    "crypto/sha1"
+    "encoding/base32"
+    "encoding/binary"
+    "encoding/json"
+    "fmt"
+    "os"
+    "strings"
+    "time"
 
 	"github.com/kovidgoyal/kitty/tools/cli"
 	"github.com/kovidgoyal/kitty/tools/tty"
@@ -34,20 +38,84 @@ func trigger_ask(name string) {
 
 }
 
+func isPasswordPrompt(msg string) bool {
+    q := strings.ToLower(msg)
+    if strings.Contains(q, "passphrase") {
+        return false
+    }
+    return strings.Contains(q, "password")
+}
+
+func isOTPPrompt(msg string) bool {
+    q := strings.ToLower(msg)
+    if strings.Contains(q, "passphrase") {
+        return false
+    }
+    if strings.Contains(q, "verification code") || strings.Contains(q, "one-time password") || strings.Contains(q, "one time password") || strings.Contains(q, "authenticator code") || strings.Contains(q, "authentication code") || strings.Contains(q, "two-factor") || strings.Contains(q, "2fa") || strings.Contains(q, "otp") || strings.Contains(q, "passcode") {
+        return true
+    }
+    return false
+}
+
+func generateTOTP(secret string, digits, period int64, t time.Time) (string, error) {
+    s := strings.ToUpper(strings.TrimSpace(secret))
+    s = strings.ReplaceAll(s, " ", "")
+    key, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(s)
+    if err != nil {
+        return "", fmt.Errorf("invalid TOTP secret: %w", err)
+    }
+    counter := uint64(t.Unix() / period)
+    var buf [8]byte
+    binary.BigEndian.PutUint64(buf[:], counter)
+    mac := hmac.New(sha1.New, key)
+    _, _ = mac.Write(buf[:])
+    sum := mac.Sum(nil)
+    off := sum[len(sum)-1] & 0x0f
+    code := (uint32(sum[off])&0x7f)<<24 | (uint32(sum[off+1])&0xff)<<16 | (uint32(sum[off+2])&0xff)<<8 | (uint32(sum[off+3]) & 0xff)
+    mod := uint32(1)
+    for i := int64(0); i < digits; i++ {
+        mod *= 10
+    }
+    val := code % mod
+    fmtstr := fmt.Sprintf("%%0%dd", digits)
+    return fmt.Sprintf(fmtstr, val), nil
+}
+
 func RunSSHAskpass() {
-	msg := os.Args[len(os.Args)-1]
-	prompt := os.Getenv("SSH_ASKPASS_PROMPT")
-	is_confirm := prompt == "confirm"
-	q_type := "get_line"
-	if is_confirm {
-		q_type = "confirm"
-	}
-	is_fingerprint_check := strings.Contains(msg, "(yes/no/[fingerprint])")
-	q := map[string]any{
-		"message":     msg,
-		"type":        q_type,
-		"is_password": !is_fingerprint_check,
-	}
+    msg := os.Args[len(os.Args)-1]
+    prompt := os.Getenv("SSH_ASKPASS_PROMPT")
+    is_confirm := prompt == "confirm"
+    q_type := "get_line"
+    if is_confirm {
+        q_type = "confirm"
+    }
+    is_fingerprint_check := strings.Contains(msg, "(yes/no/[fingerprint])")
+
+    // Auto-fill from ssh.conf if configured
+    if !is_confirm && !is_fingerprint_check {
+        host := os.Getenv("KITTY_SSH_ASKPASS_HOST")
+        user := os.Getenv("KITTY_SSH_ASKPASS_USER")
+        if host != "" {
+            if ae, err := LoadAuthForHost(host, user); err == nil && ae != nil {
+                if isPasswordPrompt(msg) && ae.Password != "" {
+                    fmt.Println(ae.Password)
+                    return
+                }
+                if isOTPPrompt(msg) && ae.TOTPSecret != "" {
+                    code, err := generateTOTP(ae.TOTPSecret, int64(ae.TOTPDigits), int64(ae.TOTPPeriod), time.Now())
+                    if err == nil {
+                        fmt.Println(code)
+                        return
+                    }
+                }
+            }
+        }
+    }
+    q := map[string]any{
+        "message":     msg,
+        "type":        q_type,
+        "is_password": !is_fingerprint_check,
+    }
 	data, err := json.Marshal(q)
 	if err != nil {
 		fatal(err)

--- a/kittens/ssh/auth_config.go
+++ b/kittens/ssh/auth_config.go
@@ -1,0 +1,124 @@
+// License: GPLv3 Copyright: 2025
+
+package ssh
+
+import (
+    "fmt"
+    "path/filepath"
+    "strconv"
+    "strings"
+
+    "github.com/kovidgoyal/kitty/tools/config"
+)
+
+// AuthEntry holds per-host auth automation data parsed from ssh.conf
+type AuthEntry struct {
+    Hostname    string // space-separated patterns, may include user@host
+    Password    string
+    TOTPSecret  string
+    TOTPDigits  int // default 6
+    TOTPPeriod  int // default 30
+}
+
+type authConfigSet struct {
+    entries []*AuthEntry
+}
+
+func (a *authConfigSet) lineHandler(key, val string) error {
+    if key == "hostname" {
+        a.entries = append(a.entries, &AuthEntry{Hostname: strings.TrimSpace(val)})
+        return nil
+    }
+    if len(a.entries) == 0 {
+        // Ensure there is always a default block
+        a.entries = append(a.entries, &AuthEntry{Hostname: "*"})
+    }
+    cur := a.entries[len(a.entries)-1]
+    switch key {
+    case "password":
+        cur.Password = strings.TrimSpace(val)
+        return nil
+    case "totp_secret":
+        cur.TOTPSecret = strings.TrimSpace(val)
+        return nil
+    case "totp_digits":
+        vv := strings.TrimSpace(val)
+        if vv == "" {
+            cur.TOTPDigits = 0
+            return nil
+        }
+        n, err := strconv.Atoi(vv)
+        if err != nil {
+            return fmt.Errorf("Failed to parse totp_digits = %#v with error: %w", val, err)
+        }
+        cur.TOTPDigits = n
+        return nil
+    case "totp_period":
+        vv := strings.TrimSpace(val)
+        if vv == "" {
+            cur.TOTPPeriod = 0
+            return nil
+        }
+        n, err := strconv.Atoi(vv)
+        if err != nil {
+            return fmt.Errorf("Failed to parse totp_period = %#v with error: %w", val, err)
+        }
+        cur.TOTPPeriod = n
+        return nil
+    default:
+        // ignore unrelated keys
+        return nil
+    }
+}
+
+// matchAuthEntry finds the best matching AuthEntry using the same matching logic as ssh.conf
+func matchAuthEntry(hostnameToMatch, usernameToMatch string, entries []*AuthEntry) *AuthEntry {
+    matcher := func(e *AuthEntry) bool {
+        for _, pat := range strings.Split(e.Hostname, " ") {
+            upat := "*"
+            if strings.Contains(pat, "@") {
+                upat, pat, _ = strings.Cut(pat, "@")
+            }
+            var hostMatched, userMatched bool
+            if matched, err := filepath.Match(pat, hostnameToMatch); matched && err == nil {
+                hostMatched = true
+            }
+            if matched, err := filepath.Match(upat, usernameToMatch); matched && err == nil {
+                userMatched = true
+            }
+            if hostMatched && userMatched {
+                return true
+            }
+        }
+        return false
+    }
+    for i := len(entries) - 1; i >= 0; i-- {
+        if matcher(entries[i]) {
+            return entries[i]
+        }
+    }
+    if len(entries) > 0 {
+        return entries[0]
+    }
+    return &AuthEntry{Hostname: "*"}
+}
+
+// LoadAuthForHost parses ssh.conf and returns the auth settings for the matching host/user
+func LoadAuthForHost(hostnameToMatch, usernameToMatch string, paths ...string) (*AuthEntry, error) {
+    acs := &authConfigSet{entries: []*AuthEntry{&AuthEntry{Hostname: "*"}}}
+    p := config.ConfigParser{LineHandler: acs.lineHandler}
+    if err := p.LoadConfig("ssh.conf", paths, nil); err != nil {
+        return nil, err
+    }
+    // Defaults
+    for _, e := range acs.entries {
+        if e.TOTPDigits == 0 {
+            e.TOTPDigits = 6
+        }
+        if e.TOTPPeriod == 0 {
+            e.TOTPPeriod = 30
+        }
+    }
+    return matchAuthEntry(hostnameToMatch, usernameToMatch, acs.entries), nil
+}
+

--- a/kittens/ssh/config.go
+++ b/kittens/ssh/config.go
@@ -374,12 +374,18 @@ func config_for_hostname(hostname_to_match, username_to_match string, cs *Config
 }
 
 func (self *ConfigSet) line_handler(key, val string) error {
-	c := self.all_configs[len(self.all_configs)-1]
-	if key == "hostname" {
-		c = NewConfig()
-		self.all_configs = append(self.all_configs, c)
-	}
-	return c.Parse(key, val)
+    c := self.all_configs[len(self.all_configs)-1]
+    if key == "hostname" {
+        c = NewConfig()
+        self.all_configs = append(self.all_configs, c)
+    }
+    // Gracefully ignore ssh.conf extensions intended for askpass automation
+    // so they are not reported as bad lines by the main config loader.
+    switch key {
+    case "password", "totp_secret", "totp_period", "totp_digits":
+        return nil
+    }
+    return c.Parse(key, val)
 }
 
 func load_config(hostname_to_match string, username_to_match string, overrides []string, paths ...string) (*Config, []config.ConfigLine, error) {

--- a/kittens/ssh/main.go
+++ b/kittens/ssh/main.go
@@ -646,11 +646,14 @@ func run_ssh(ssh_args, server_args, found_extra_args []string) (rc int, err erro
 		}
 		cmd = slices.Insert(cmd, insertion_point, control_master_args...)
 	}
-	use_kitty_askpass := host_opts.Askpass == Askpass_native || (host_opts.Askpass == Askpass_unless_set && os.Getenv("SSH_ASKPASS") == "")
-	need_to_request_data := true
-	if use_kitty_askpass {
-		need_to_request_data = set_askpass()
-	}
+    use_kitty_askpass := host_opts.Askpass == Askpass_native || (host_opts.Askpass == Askpass_unless_set && os.Getenv("SSH_ASKPASS") == "")
+    need_to_request_data := true
+    if use_kitty_askpass {
+        need_to_request_data = set_askpass()
+        // Provide host/user to askpass so it can lookup auth settings in ssh.conf
+        os.Setenv("KITTY_SSH_ASKPASS_HOST", hostname_for_match)
+        os.Setenv("KITTY_SSH_ASKPASS_USER", uname)
+    }
 	master_is_functional := func() bool {
 		if master_checked {
 			return master_is_alive


### PR DESCRIPTION
Overview
- Adds optional automation to auto-enter password and generate TOTP when prompted by OpenSSH, driven by ssh.conf per-host configuration. Falls back to kitty’s askpass UI for other prompts.

Motivation
- Some environments disallow or don’t reliably accept one‑way pubkey‑only authentication, or enforce keyboard‑interactive flows (password + TOTP). This provides a lightweight, opt‑in way to reduce repetitive manual entry while preserving the ssh kitten UX and connection latency benefits.

Usage
- In ~/.config/kitty/ssh.conf under the matching hostname block:
  - password <plain-text password>
  - totp_secret <base32 secret>
  - totp_digits <optional, default 6>
  - totp_period <optional, default 30>
- Works with askpass set to native/unless-set. Only login password/OTP prompts are auto‑answered; host key confirmations and key passphrases are not.

Security
- Secrets in ssh.conf are plain text; users should enforce strict permissions (e.g., 600) or avoid storing passwords if unacceptable. TOTP is generated per RFC 6238 (SHA1, base32 secret).

Implementation
- kittens/ssh/auth_config.go: Parse password/totp_* from ssh.conf with same hostname matching semantics as existing ssh kitten config blocks.
- kittens/ssh/config.go: Ignore these new keys in the primary config loader to avoid “bad line” warnings.
- kittens/ssh/main.go: Export KITTY_SSH_ASKPASS_HOST/USER so askpass can resolve the correct host block.
- kittens/ssh/askpass.go: Detect password/OTP prompts; auto‑print configured password or generated TOTP; otherwise fallback to kitty askpass dialog.

Notes
- Non‑breaking and opt‑in; no behavior change unless users add the new keys in ssh.conf.
- Happy to refine prompt detection strings or support alternative secret stores if desired.
